### PR TITLE
feat: add authorization to stats endpoint

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -7,7 +7,7 @@ module.exports = {
   PORT: process.env.PORT || 3000,
   API_VERSION: process.env.API_VERSION || 'v5',
   AUTH_SECRET: process.env.AUTH_SECRET || 'mysecret',
-  VALID_ISSUERS: process.env.VALID_ISSUERS || '["https://api.topcoder-dev.com", "https://api.topcoder.com", "https://topcoder-dev.auth0.com/"]',
+  VALID_ISSUERS: process.env.VALID_ISSUERS || '["https://api.topcoder-dev.com", "https://api.topcoder.com", "https://topcoder-dev.auth0.com/", "https://auth.topcoder-dev.com/"]',
 
   // used to get M2M token
   AUTH0_URL: process.env.AUTH0_URL,
@@ -27,7 +27,7 @@ module.exports = {
     TAGS_API_VERSION: process.env.TAGS_API_VERSION || '/v3',
     TAGS_FILTER: process.env.TAGS_FILTER || '/tags/?filter=domain%3DSKILLS%26status%3DAPPROVED&limit=1000'
   },
-  GROUPS_API_URL: process.env.GROUPS_API_URL, //|| 'https://api.topcoder-dev.com/v5/groups',
+  GROUPS_API_URL: process.env.GROUPS_API_URL, // || 'https://api.topcoder-dev.com/v5/groups',
   // aws config params
   AMAZON: {
     AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
@@ -111,5 +111,10 @@ module.exports = {
   // Member Statistics identifiable info fields, only admin, M2M, or member himself can fetch these fields
   STATISTICS_SECURE_FIELDS: process.env.STATISTICS_SECURE_FIELDS
     ? process.env.STATISTICS_SECURE_FIELDS.split(',')
-    : ['createdBy', 'updatedBy']
+    : ['createdBy', 'updatedBy'],
+
+  // Public group id
+  PUBLIC_GROUP_ID: process.env.PUBLIC_GROUP_ID || '10',
+  // Private group ids will be excluded from results for non-admin users.
+  PRIVATE_GROUP_IDS: JSON.parse(process.env.PRIVATE_GROUP_IDS || '["20000000"]')
 }

--- a/docs/member-api.postman_collection.json
+++ b/docs/member-api.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "03129edd-111f-4875-924d-2ffd2c0c18eb",
+		"_postman_id": "2e554101-d99e-4522-8ce5-39ff8e6cca0e",
 		"name": "member-api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -3617,13 +3617,13 @@
 									}
 								],
 								"url": {
-									"raw": "{{URL}}/members/standlove/stats/history?fields=userId,handle,DATA_SCIENCE,DEVELOP,createdBy",
+									"raw": "{{URL}}/members/denis/stats/history?fields=userId,handle,DATA_SCIENCE,DEVELOP,createdBy",
 									"host": [
 										"{{URL}}"
 									],
 									"path": [
 										"members",
-										"standlove",
+										"denis",
 										"stats",
 										"history"
 									],
@@ -3667,20 +3667,138 @@
 									}
 								],
 								"url": {
-									"raw": "{{URL}}/members/standlove/stats/history?groupIds=10,20000000&fields=userId,handle,groupId",
+									"raw": "{{URL}}/members/denis/stats/history?groupIds=10,20000001&fields=userId,handle,groupId",
 									"host": [
 										"{{URL}}"
 									],
 									"path": [
 										"members",
-										"standlove",
+										"denis",
 										"stats",
 										"history"
 									],
 									"query": [
 										{
 											"key": "groupIds",
-											"value": "10,20000000"
+											"value": "10,20000001"
+										},
+										{
+											"key": "fields",
+											"value": "userId,handle,groupId"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get member history private statistics - groupIds by admin",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{admin_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{URL}}/members/denis/stats/history?groupIds=10,20000001&fields=userId,handle,groupId",
+									"host": [
+										"{{URL}}"
+									],
+									"path": [
+										"members",
+										"denis",
+										"stats",
+										"history"
+									],
+									"query": [
+										{
+											"key": "groupIds",
+											"value": "10,20000001"
+										},
+										{
+											"key": "fields",
+											"value": "userId,handle,groupId"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get member history private statistics - groupIds by member himself",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{user_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{URL}}/members/denis/stats/history?groupIds=10,20000001&fields=userId,handle,groupId",
+									"host": [
+										"{{URL}}"
+									],
+									"path": [
+										"members",
+										"denis",
+										"stats",
+										"history"
+									],
+									"query": [
+										{
+											"key": "groupIds",
+											"value": "10,20000001"
 										},
 										{
 											"key": "fields",
@@ -3721,13 +3839,13 @@
 									}
 								],
 								"url": {
-									"raw": "{{URL}}/members/standlove/stats/history?groupIds=10,20000000,20000010&fields=userId,handle,groupId",
+									"raw": "{{URL}}/members/denis/stats/history?groupIds=10,20000000,20000010&fields=userId,handle,groupId",
 									"host": [
 										"{{URL}}"
 									],
 									"path": [
 										"members",
-										"standlove",
+										"denis",
 										"stats",
 										"history"
 									],
@@ -4063,6 +4181,114 @@
 							"response": []
 						},
 						{
+							"name": "get member private statistics with admin token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{admin_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{URL}}/members/denis/stats?groupIds=10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9",
+									"host": [
+										"{{URL}}"
+									],
+									"path": [
+										"members",
+										"denis",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "groupIds",
+											"value": "10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get member private statistics by user himself",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{user_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{URL}}/members/denis/stats?groupIds=10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9",
+									"host": [
+										"{{URL}}"
+									],
+									"path": [
+										"members",
+										"denis",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "groupIds",
+											"value": "10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "get member private statistics - multiple group Ids",
 							"event": [
 								{
@@ -4089,6 +4315,64 @@
 										"key": "Content-Type",
 										"type": "text",
 										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{URL}}/members/denis/stats?groupIds=10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9&fields=userId,handle,wins,groupId,challenges",
+									"host": [
+										"{{URL}}"
+									],
+									"path": [
+										"members",
+										"denis",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "groupIds",
+											"value": "10,d6bf6bb6-457c-461c-a4d6-0a6b1a87fde9"
+										},
+										{
+											"key": "fields",
+											"value": "userId,handle,wins,groupId,challenges"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "get member private statistics - multiple group Ids with admin token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{admin_token}}",
+										"type": "text"
 									}
 								],
 								"url": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -881,7 +881,7 @@ paths:
           in: query
           required: false
           type: string
-          description: comma separated group ids
+          description: comma separated group ids (returns public stats if group ids is not provided)
         - name: fields
           in: query
           required: false
@@ -954,7 +954,7 @@ paths:
           in: query
           required: false
           type: string
-          description: comma separated group ids
+          description: comma separated group ids (returns members public history statistics if groupIds is not provided)
         - name: fields
           in: query
           required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -4598,8 +4598,8 @@
       }
     },
     "tc-core-library-js": {
-      "version": "github:appirio-tech/tc-core-library-js#df0b36c51cf80918194cbff777214b3c0cf5a151",
-      "from": "github:appirio-tech/tc-core-library-js#v2.6.4",
+      "version": "github:appirio-tech/tc-core-library-js#081138e1f5eae76171abeff34b8f326b3fb2b504",
+      "from": "github:appirio-tech/tc-core-library-js#v2.6.5",
       "requires": {
         "axios": "^0.19.0",
         "bunyan": "^1.8.12",

--- a/src/common/eshelper.js
+++ b/src/common/eshelper.js
@@ -3,8 +3,6 @@
  */
 const _ = require('lodash')
 const config = require('config')
-const helper = require('../common/helper')
-const { response } = require('express')
 
 /**
  * Fetch members profile form ES
@@ -151,7 +149,7 @@ async function getSuggestion (query, esClient, currentUser) {
  * @returns {Object} total
  */
 function getTotal (docs) {
-  const total = docs.hits.total
+  let total = docs.hits.total
   if (_.isObject(total)) {
     total = total.value || 0
   }

--- a/src/scripts/seed-data.js
+++ b/src/scripts/seed-data.js
@@ -175,6 +175,59 @@ const historyStats = {
   updatedBy: 'test2'
 }
 
+const historyStatsPrivate = {
+  userId: 123,
+  groupId: 20000001,
+  handle: 'denis',
+  handleLower: 'denis',
+  DEVELOP: {
+    subTracks: [
+      {
+        id: 1111,
+        name: 'name',
+        history: [
+          {
+            challengeId: 789789,
+            challengeName: 'test',
+            ratingDate: '2020-02-15T14:04:22.544Z',
+            newRating: 1888
+          }
+        ]
+      }
+    ]
+  },
+  DATA_SCIENCE: {
+    SRM: {
+      history: [
+        {
+          challengeId: 754545,
+          challengeName: 'test2',
+          date: '2020-02-15T14:04:22.544Z',
+          rating: 1565,
+          placement: 1,
+          percentile: 100
+        }
+      ]
+    },
+    MARATHON_MATCH: {
+      history: [
+        {
+          challengeId: 121212,
+          challengeName: 'test3',
+          date: '2020-02-15T14:04:22.544Z',
+          rating: 1232,
+          placement: 2,
+          percentile: 80
+        }
+      ]
+    }
+  },
+  updatedAt: '2020-02-08T07:38:50.088Z',
+  createdAt: '2020-02-09T07:38:50.088Z',
+  createdBy: 'test1',
+  updatedBy: 'test2'
+}
+
 const memberStats = {
   userId: 123,
   handle: 'denis',
@@ -619,6 +672,7 @@ async function seedData () {
   await helper.create('MemberDistributionStats', distribution1)
   await helper.create('MemberDistributionStats', distribution2)
   await helper.create('MemberHistoryStats', historyStats)
+  await helper.create('MemberHistoryStatsPrivate', historyStatsPrivate)
   await helper.create('MemberStats', memberStats)
   await helper.create('MemberStatsPrivate', memberPrivateStats)
   await helper.create('MemberFinancial', memberFinancial)

--- a/src/services/MemberService.js
+++ b/src/services/MemberService.js
@@ -148,7 +148,7 @@ async function updateMember (currentUser, handle, query, data) {
       }
     }
     let checkEmail = await esClient.count(esCheckEmail)
-    if (checkEmail.count == 0) {
+    if (checkEmail.count === 0) {
       data.newEmail = data.email
       delete data.email
       data.emailVerifyToken = uuid()

--- a/src/services/MiscService.js
+++ b/src/services/MiscService.js
@@ -2,11 +2,9 @@
  * This service provides operations of statistics.
  */
 
-const _ = require('lodash')
 const Joi = require('joi')
 const helper = require('../common/helper')
 const logger = require('../common/logger')
-const errors = require('../common/errors')
 
 const MEMBER_FINANCIAL_FIELDS = ['userId', 'amount', 'status', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy']
 

--- a/src/services/SearchService.js
+++ b/src/services/SearchService.js
@@ -18,7 +18,7 @@ const MEMBER_AUTOCOMPLETE_FIELDS = ['userId', 'handle', 'handleLower', 'firstNam
   'status', 'email', 'createdAt', 'updatedAt']
 
 var MEMBER_STATS_FIELDS = ['userId', 'handle', 'handleLower', 'maxRating',
-  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'copilot']
+  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'COPILOT']
 
 const esClient = helper.getESClient()
 


### PR DESCRIPTION
* require authorization to show private community stats of a member
* certain private community stats can be protected from non-admin members of that community via configuration
* admins can access all stats