### PR TITLE
Search tweaks

### DIFF
--- a/src/common/eshelper.js
+++ b/src/common/eshelper.js
@@ -294,7 +294,7 @@ async function searchMembersSkills (skillIds, skillsBooleanOperator, page, perPa
       'emsiSkills.name',
       'handle',
       'handleLower',
-      'profilePic',
+      'photoURL',
       'firstName',
       'lastName',
       'homeCountryCode',

--- a/src/common/eshelper.js
+++ b/src/common/eshelper.js
@@ -287,8 +287,20 @@ async function searchMembersSkills (skillIds, skillsBooleanOperator, page, perPa
     type: config.get('ES.MEMBER_PROFILE_ES_TYPE'),
     size: 10000,
     scroll: '90s',
+    _source:[  
+      'userId',
+      'emsiSkills.skillId',
+      'emsiSkills.skillSources',
+      'emsiSkills.name',
+      'handle',
+      'handleLower',
+      'profilePic',
+      'firstName',
+      'lastName',
+      'homeCountryCode',
+      'addresses'
+    ],
     body: {
-      sort: [{ createdAt: { order: 'desc' } }],
       query: {
         bool: {
           filter: { bool: {} }
@@ -330,6 +342,7 @@ async function searchMembersSkills (skillIds, skillsBooleanOperator, page, perPa
   const response = await esClient.search(esQuerySkills)
 
   responseQueue.push(response)
+  
   while (responseQueue.length) {
     const body = responseQueue.shift()
     // collect the titles from this response


### PR DESCRIPTION
* Added some performance enhancements to skill search
* Secondary skill search sort order is now the number of TC verified skills in descending order (skills in emsiSkills array with `skillSource` contains `ChallengeWin`)