### PR TITLE
PROD-4396 - add new endpoint to hash user's userId -> dev

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -150,5 +150,9 @@ module.exports = {
     TOKEN: process.env.LOOKER_API_TOKEN || 'TOKEN',
     //24 hours, in milliseconds
     CACHE_DURATION: 1000 * 60 * 60 * 24
+  },
+
+  HASHING_KEYS: {
+    USERFLOW: process.env.USERFLOW_PRIVATE_KEY,
   }
 }

--- a/src/controllers/MemberController.js
+++ b/src/controllers/MemberController.js
@@ -23,6 +23,16 @@ async function getProfileCompleteness (req, res) {
 }
 
 /**
+ * Get member's hashed user id as signature for various UI api integrations
+ * @param {Object} req the request
+ * @param {Object} res the response
+ */
+async function getMemberUserIdSignature (req, res) {
+  const result = await service.getMemberUserIdSignature(req.authUser, req.query)
+  res.send(result)
+}
+
+/**
  * Update member data, only passed fields are updated
  * @param {Object} req the request
  * @param {Object} res the response
@@ -55,6 +65,7 @@ async function uploadPhoto (req, res) {
 module.exports = {
   getMember,
   getProfileCompleteness,
+  getMemberUserIdSignature,
   updateMember,
   verifyEmail,
   uploadPhoto

--- a/src/routes.js
+++ b/src/routes.js
@@ -40,6 +40,14 @@ module.exports = {
       scopes: [MEMBERS.READ, MEMBERS.ALL]
     }
   },
+  '/members/uid-signature': {
+    get: {
+      controller: 'MemberController',
+      method: 'getMemberUserIdSignature',
+      auth: 'jwt',
+      scopes: [MEMBERS.READ, MEMBERS.ALL]
+    }
+  },
   '/members/:handle': {
     get: {
       controller: 'MemberController',


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-4396

Adds a new endpoint that hashes the current user's userId to support integration with Userflow.
It allows for a `type` parameter for future expandability options. Currently only "userflow" value is allowed and mandatory.

A new env variable `USERFLOW_PRIVATE_KEY` will have to be defined, I can provide the keys later on.