### PR TITLE
Test fix for TAL-88

### DIFF
--- a/src/services/MemberTraitService.js
+++ b/src/services/MemberTraitService.js
@@ -224,9 +224,7 @@ async function updateTraits (currentUser, handle, data) {
     }
     // update db
     var updateDb = await helper.update(existing, {})
-    
-    // update the skill score deduction
-    await updateSkillScoreDeduction(currentUser, member)
+   
     // convert date time
     const origUpdateDb = updateDb.originalItem()
     origUpdateDb.createdAt = new Date(origUpdateDb.createdAt).getTime()


### PR DESCRIPTION
We don’t really need to recalculate the skill score deduction on a trait _update_ - only create or removal.

There seems to be a sync issue where we:

* Remove a trait
* Calculate the skill score
* Save the skill score
* Raise a bus event for the deleted trait
* It’s processed by the onboarding processor
* The onboarding processor updates the “onboarding” trait via the member API, causing the skill score deduction to be calculated again here, potentially reverting the change above, if the trait hasn’t been fully deleted yet.